### PR TITLE
fix addon resolution directory when specifier is different that '.'

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ module.exports = class DriveBundle {
     for (const addon of await Promise.all(addonsPending)) {
       if (!addon) continue
 
-      const dir = this._resolutionKey(unixResolve(addon.referrer, '..', addon.input), true)
+      const dir = this._resolutionKey(unixResolve(unixResolve(addon.referrer, '..'), addon.input), true)
       let r = resolutions[dir] = resolutions[dir] || {}
       r['bare:addon'] = addon.output
 


### PR DESCRIPTION
Addon resolution directory was wrong for specifier different that '.' because unix-path-resolve only takes two arguments.